### PR TITLE
Fix issue with multi-class classification

### DIFF
--- a/R/functions_EM_helper.R
+++ b/R/functions_EM_helper.R
@@ -226,7 +226,6 @@ get_word_prob_NB <- function(.D_train, .C_train, .beta = NA){
   # if .beta is not provided, use (2,2,...) as beta
 
 
-  print(paste("betas: ", dim(.beta - 1)))
   if (length(beta) == 1 && all(is.na(.beta))){
     .beta <- rep(2, ncol(.D_train))
     # NOTE:
@@ -235,7 +234,7 @@ get_word_prob_NB <- function(.D_train, .C_train, .beta = NA){
     .beta <- cbind(.beta_neg, .beta)
     colnames(.beta) <- NULL # make sure .beta does not show up in the col names
   }
-  
+
 	num <- log(.beta - 1 + Matrix::crossprod(.D_train, .C_train))
 	den <- apply(num, 2, matrixStats::logSumExp)
 	return(sweep(num, 2, den, "-"))

--- a/R/functions_EM_helper.R
+++ b/R/functions_EM_helper.R
@@ -226,6 +226,7 @@ get_word_prob_NB <- function(.D_train, .C_train, .beta = NA){
   # if .beta is not provided, use (2,2,...) as beta
 
 
+  print(paste("betas: ", dim(.beta - 1)))
   if (length(beta) == 1 && all(is.na(.beta))){
     .beta <- rep(2, ncol(.D_train))
     # NOTE:
@@ -234,7 +235,7 @@ get_word_prob_NB <- function(.D_train, .C_train, .beta = NA){
     .beta <- cbind(.beta_neg, .beta)
     colnames(.beta) <- NULL # make sure .beta does not show up in the col names
   }
-
+  
 	num <- log(.beta - 1 + Matrix::crossprod(.D_train, .C_train))
 	den <- apply(num, 2, matrixStats::logSumExp)
 	return(sweep(num, 2, den, "-"))


### PR DESCRIPTION
There are two main changes in this PR to fix an issue a user found with multi-class classification:

1. **Removal of "n_class" as a parameter.** The number of classes can be calculated by the number of items in "labels." Having "n_class" as an additional parameter makes it possible to have a contradiction between the two.
2.  **Checks on "n_cluster" added.** The default of n_cluster is now NULL instead of 2. For binary classification (2 classes), n_cluster must be greater than or equal to 2. For multi-class classification (number of classes greater than 2), n_cluster must be equal to n_class.